### PR TITLE
fix: improve word refresh logic to handle temporary and saved words differently

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everetch",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "type": "module",
   "description": "A slim word memo application",
   "main": "lib/main.js",


### PR DESCRIPTION
- Prevent unnecessary database updates for temporary words during refresh
- Ensure saved words are properly updated in the database and UI
- Bump version to 1.4.7 for the patch release